### PR TITLE
Add missing lmfit to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ scikit-learn = "^1.2.1"
 space-rocks = "^1.7.2"
 tox = "^4.4.5"
 importlib-resources = "^5.10.2"
+lmfit = "^1.2.0"
 
 [tool.poetry.extras]
 docs = ["sphinx", "sphinx-redactor-theme"]


### PR DESCRIPTION
This seems to be necessary when importing https://github.com/maxmahlke/classy/blob/main/classy/feature.py. 
I didn't end up include the result of `poetry lock` here since it would have modified most of the poetry.lock file.