### PR TITLE
Fix crash when trying to load spectrum

### DIFF
--- a/classy/sources/pds/reddy_nea_mc.py
+++ b/classy/sources/pds/reddy_nea_mc.py
@@ -60,6 +60,7 @@ def _create_index(PATH_REPO):
                     "shortbib": shortbib,
                     "bibcode": bibcode,
                     "filename": str(file_).split("/classy/")[1],
+                    "module": "reddy_nea_mc",
                     "source": "Misc",
                     "host": "pds",
                     "collection": "reddy_nea_mc",

--- a/classy/sources/pds/s3os2.py
+++ b/classy/sources/pds/s3os2.py
@@ -56,6 +56,7 @@ def _create_index(PATH_REPO):
                     "shortbib": SHORTBIB,
                     "bibcode": BIBCODE,
                     "filename": str(file_).split("/classy/")[1],
+                    "module": "s3os2",
                     "source": "S3OS2",
                     "host": "PDS",
                     "collection": "s3os2",

--- a/classy/sources/pds/sawyer.py
+++ b/classy/sources/pds/sawyer.py
@@ -53,6 +53,7 @@ def _create_index(PATH_REPO):
                     "shortbib": shortbib,
                     "bibcode": bibcode,
                     "filename": str(file_).split("/classy/")[1],
+                    "module": "sawyer",
                     "source": "Misc",
                     "host": "pds",
                     "collection": "sawyer",

--- a/classy/sources/pds/willman_iannini.py
+++ b/classy/sources/pds/willman_iannini.py
@@ -59,6 +59,7 @@ def _create_index(PATH_REPO):
                     "SHORTBIB": SHORTBIB,
                     "bibcode": BIBCODE,
                     "filename": str(file_).split("/classy/")[1],
+                    "module": "willman_iannini",
                     "source": "Misc",
                     "host": "PDS",
                     "collection": "willman_iannini",


### PR DESCRIPTION
A basic `classy spectra ceres` command was crashing:

<details><summary>Traceback</summary>
<pre>
Traceback (most recent call last):
  File "/home/ari/.cache/pypoetry/virtualenvs/space-classy-yXkZV_lt-py3.11/bin/classy", line 8, in <module>
    sys.exit(cli_classy())
             ^^^^^^^^^^^^
  File "/home/ari/.cache/pypoetry/virtualenvs/space-classy-yXkZV_lt-py3.11/lib/python3.11/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ari/.cache/pypoetry/virtualenvs/space-classy-yXkZV_lt-py3.11/lib/python3.11/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/ari/.cache/pypoetry/virtualenvs/space-classy-yXkZV_lt-py3.11/lib/python3.11/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ari/.cache/pypoetry/virtualenvs/space-classy-yXkZV_lt-py3.11/lib/python3.11/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ari/.cache/pypoetry/virtualenvs/space-classy-yXkZV_lt-py3.11/lib/python3.11/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ari/dev/karman/classy/classy/cli.py", line 97, in spectra
    spectra = core.Spectra(id_, source=source)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/functools.py", line 946, in _method
    return method.__get__(obj, cls)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ari/dev/karman/classy/classy/core.py", line 639, in id_
    spectra = cache.load_spectra(spectra)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ari/dev/karman/classy/classy/cache.py", line 34, in load_spectra
    spectra = [sources.load_spectrum(spec) for _, spec in idx_spectra.iterrows()]
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ari/dev/karman/classy/classy/cache.py", line 34, in <listcomp>
    spectra = [sources.load_spectrum(spec) for _, spec in idx_spectra.iterrows()]
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ari/dev/karman/classy/classy/sources/__init__.py", line 45, in load_spectrum
    module = getattr(host, idx.module.lower())
                           ^^^^^^^^^^^^^^^^
AttributeError: 'float' object has no attribute 'lower'

</pre>
</details> 

After this fix, you'll have to rebuild the index with `classy status`.