### PR TITLE
Remove pyqt5 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ or
 $ pip install space-classy
 ```
 
+To use interactive GUI features, you'll also need to install one of these packages to work with pyqtgraph: PyQt5, PyQt6, PySide2, or PySide6.
+
 # Documentation
 
 Check out the documentation at [classy.readthedocs.io](https://classy.readthedocs.io/en/latest/).

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ or
 $ pip install space-classy
 ```
 
-To use interactive GUI features, you'll also need to install one of these packages to work with pyqtgraph: PyQt5, PyQt6, PySide2, or PySide6.
+To use interactive GUI features, you'll also need to install one of these packages to work with pyqtgraph: PyQt5, PyQt6, PySide2, or PySide6. Running `pip install space-classy[gui]` will automatically install space-classy alone with one of the necessary GUI libraries.
 
 # Documentation
 

--- a/classy/gui.py
+++ b/classy/gui.py
@@ -5,10 +5,14 @@ import sys
 import classy
 from classy.log import logger
 
-import pyqtgraph as pg
-
-# from pyqtgraph.Qt import QtCore, QtWidgets
-from pyqtgraph.Qt import QtWidgets, QtGui
+try:
+    import pyqtgraph as pg
+    from pyqtgraph.Qt import QtWidgets
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(
+        "The Graphical User Interface of classy requires the pyqt5 package. "
+        "Run 'pip install \"space-classy[gui]\" to install it.'"
+    ) from e
 
 
 class InteractiveFeatureFit(QtWidgets.QMainWindow):

--- a/classy/gui.py
+++ b/classy/gui.py
@@ -8,7 +8,7 @@ from classy.log import logger
 try:
     import pyqtgraph as pg
     from pyqtgraph.Qt import QtWidgets
-except ModuleNotFoundError as e:
+except (Exception, ModuleNotFoundError) as e:
     raise ModuleNotFoundError(
         "The Graphical User Interface of classy requires the pyqtgraph and pyside6 packages. "
         "Run 'pip install \"space-classy[gui]\" to install it.'"

--- a/classy/gui.py
+++ b/classy/gui.py
@@ -8,7 +8,7 @@ from classy.log import logger
 try:
     import pyqtgraph as pg
     from pyqtgraph.Qt import QtWidgets
-except (Exception, ModuleNotFoundError) as e:
+except Exception as e:
     raise ModuleNotFoundError(
         "The Graphical User Interface of classy requires the pyqtgraph and pyside6 packages. "
         "Run 'pip install \"space-classy[gui]\" to install it.'"

--- a/classy/gui.py
+++ b/classy/gui.py
@@ -10,7 +10,7 @@ try:
     from pyqtgraph.Qt import QtWidgets
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError(
-        "The Graphical User Interface of classy requires the pyqt5 package. "
+        "The Graphical User Interface of classy requires the pyqtgraph and pyside6 packages. "
         "Run 'pip install \"space-classy[gui]\" to install it.'"
     ) from e
 

--- a/classy/preprocessing.py
+++ b/classy/preprocessing.py
@@ -4,7 +4,6 @@ import sklearn
 
 from classy import config
 
-from classy import gui
 from classy.log import logger
 from classy import tools
 
@@ -237,4 +236,5 @@ def _normalize_l2(refl):
 
 def smooth_interactive(spec):
     """"""
+    from classy import gui
     gui.smooth(spec)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ space-rocks = ">=1.7.2"
 
 [tool.poetry.extras]
 docs = ["sphinx", "sphinx-redactor-theme", "sphinx_design", "sphinx-hoverxref", "jinja2", 'furo', "sphinx-copybutton"]
-gui = ['pyqt5']
+gui = ['pyside6']
 
 [tool.pytest.ini_options]
 addopts = "-v --cov=classy --cov-report html"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,33 +13,21 @@ include = ["data/mixnorm", 'data/mcfa']
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-sphinx = {version = "^4", optional = true}
-sphinx-redactor-theme = {version = "^0.0.1", optional = true}
-sphinx-hoverxref = {version = "*", optional = true}
-jinja2 = {version = "<3.1", optional = true}
 aiohttp = ">=3.8"
-mcfa = "^0.1"
-pyqtgraph='>=0.13'
-pandas = "^1.4.2"
-numpy = ">=1.22.3"
 click = ">=8.1.2"
+importlib-resources = ">=5.10.2"
+lmfit = ">=1.2.0"
+mcfa = "^0.1"
+numpy = ">=1.22.3"
+pandas = ">=1.4.2"
+pyqtgraph='>=0.13'
 rich = ">=12.2.0"
-sphinx_design = "^0.3.0"
-sphinx-copybutton = "^0.5.0"
-furo = "^2022.9.15"
-scikit-learn = "^1.2.1"
+scikit-learn = ">=1.2.1"
 space-rocks = ">=1.7.2"
-tox = "^4.4.5"
-importlib-resources = "^5.10.2"
-lmfit = "^1.2.0"
 
 [tool.poetry.extras]
-docs = ["sphinx", "sphinx-redactor-theme"]
-
-[tool.poetry.dev-dependencies]
-sphinx-redactor-theme = "^0.0.1"
-sphinx-hoverxref = {version = "*", optional = true}
-jinja2 = "<3.1"
+docs = ["sphinx", "sphinx-redactor-theme", "sphinx_design", "sphinx-hoverxref", "jinja2", 'furo', "sphinx-copybutton"]
+gui = ['pyqt5']
 
 [tool.pytest.ini_options]
 addopts = "-v --cov=classy --cov-report html"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ jinja2 = {version = "<3.1", optional = true}
 aiohttp = ">=3.8"
 mcfa = "^0.1"
 pyqtgraph='>=0.13'
-pyqt5='>=5.15.9'
 pandas = "^1.4.2"
 numpy = ">=1.22.3"
 click = ">=8.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,13 @@ lmfit = ">=1.2.0"
 mcfa = "^0.1"
 numpy = ">=1.22.3"
 pandas = ">=1.4.2"
-pyqtgraph='>=0.13'
 rich = ">=12.2.0"
 scikit-learn = ">=1.2.1"
 space-rocks = ">=1.7.2"
 
 [tool.poetry.extras]
 docs = ["sphinx", "sphinx-redactor-theme", "sphinx_design", "sphinx-hoverxref", "jinja2", 'furo', "sphinx-copybutton"]
-gui = ['pyside6']
+gui = ['pyside6', 'pyqtgraph']
 
 [tool.pytest.ini_options]
 addopts = "-v --cov=classy --cov-report html"


### PR DESCRIPTION
Sorry for the churn on this. I realized there's no binary wheel for PyQt5 for linux-aarch64, so installing classy on an M1 (ARM) Mac inside an official Python Docker image (or running Linux natively without a precompiled pyqt5 package) won't work without some shenanigans to compile PyQt5 from source. Only PySide6 has a binary wheel available for ARM/Linux. I also changed one of the two `import gui` lines to only run when you use an interactive function, so Qt isn't needed if you don't use those anyway.

Note that I wasn't able to update poetry.lock because of Python versioning conflicts, but I think that was true before my change too.