### PR TITLE
Fix typo in arXiv link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 A tool to explore, download, analyse, and classify asteroid reflectance
 spectra. Originally designed for classification in the taxonomy of [Mahlke,
-Carry, and Mattei 2022](https://arxiv.org/abs/2203.11229>), it now offers
+Carry, and Mattei 2022](https://arxiv.org/abs/2203.11229), it now offers
 multiple taxonomic systems and a suite of quality-of-life features for
 spectroscopic analysis.
 


### PR DESCRIPTION
A very small fix, but when clicking the link to your paper in the README, I noticed the link was broken. This fixes it