### PR TITLE
feat: add help docs for custom plot in notebooks

### DIFF
--- a/docs/core.rst
+++ b/docs/core.rst
@@ -409,6 +409,10 @@ adapt the figure before opening the plot, you can set ``show=False``. This can
 be useful e.g. if you would like to add :ref:`template spectra of taxonomic
 classes <taxonomies>` for comparison.
 
+If you encounter issues with custom plots in Jupyter Notebooks, add `%matplotlib inline`
+at the first line of your notebook. Also, append a `;` after any plot-invoking code to
+prevent automatic plot display and ensure the final plt.show() works correctly.
+
 .. code-block:: python
 
   >>> import matplotlib.pyplot as plt
@@ -416,6 +420,9 @@ classes <taxonomies>` for comparison.
   >>> fig, ax = spectra.plot(show=False)
   >>> templates = classy.taxonomies.mahlke.load_templates()
   >>> ax.plot(templates['S'].wave, templates['S'].refl, label='Template S', ls=":")
+  >>> # if you are using a Jupyter notebook, you should use the following line insead
+  >>> # fig, ax = spectra.plot(show=False); <-- note the ';' at the end
+  >>> # ax.plot(templates['S'].wave, templates['S'].refl, label='Template S', ls=":"); <-- note the ';' at the end
   >>> ax.legend()
   >>> plt.show()
 

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -420,7 +420,7 @@ prevent automatic plot display and ensure the final plt.show() works correctly.
   >>> fig, ax = spectra.plot(show=False)
   >>> templates = classy.taxonomies.mahlke.load_templates()
   >>> ax.plot(templates['S'].wave, templates['S'].refl, label='Template S', ls=":")
-  >>> # if you are using a Jupyter notebook, you should use the following line insead
+  >>> # if you are using a Jupyter notebook, you should use the following line instead
   >>> # fig, ax = spectra.plot(show=False); <-- note the ';' at the end
   >>> # ax.plot(templates['S'].wave, templates['S'].refl, label='Template S', ls=":"); <-- note the ';' at the end
   >>> ax.legend()


### PR DESCRIPTION
Hi there. Sorry to produce too many garbage PRs in your project :disappointed_relieved:, but due to my terrible git skills, I have to open a new one here.
Accidentally I found the plot function of Spectra/Spectrum class is deeply wrapped, and it will cause some issues when user try to use them in jupyter notebooks.

The details are when a user plot many spectrum objects in one cell or add some custom plots after sp.plot(show=False), the result cell won't behave as expected. In some situations it output many incomplete figures and in other situations it just show nothing.

The best way to solve this is very easy: add a ; after any code that will automatically invoke plot behavior. The notebooks display objects as default and ; will prevent this.

I've added this caution to your docs in the chapter of Basic Usage/ Plotting spectra. As I can't build the docs, if you find any content not display correctly, feel free to contact me.